### PR TITLE
Add GitHub Pages setup instructions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,21 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs
+      - uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ See `STYLE_DIRECTIVE.md` for detailed styling information and `DOCUMENTATION.md`
 Minimum supported screen width: 320px
 Maximum recommended zoom level: 150%
 
+## Hosting via GitHub Pages
+
+The `docs/` folder contains a static build of the site.
+To publish it using GitHub Pages:
+
+1. Open your repository on GitHub and go to **Settings** › **Pages**.
+2. Set the **Source** to the `main` branch and select `/docs` as the folder.
+3. Save. GitHub will display a URL like
+   `https://<username>.github.io/<repository>/`.
+4. After a minute, visit that link to see `index.html` with chat
+   functionality.
+
 ## Contributing
 
 Please read `DOCUMENTATION.md` for details on our code of conduct and the process for submitting pull requests.


### PR DESCRIPTION
## Summary
- document how to enable GitHub Pages for the `docs/` folder
- add workflow file to automate pages deployment

## Testing
- `codespell README.md .github/workflows/pages.yml -q 3`
- `markdown-link-check README.md -q`


------
https://chatgpt.com/codex/tasks/task_e_6841929bd9648330a7a88c475d949130