### PR TITLE
Simplify login flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,22 +35,7 @@
             <label for="loginPassword" class="form-label">Password</label>
             <input type="password" id="loginPassword" class="form-input" required>
         </div>
-        <div class="form-group">
-            <label for="loginRole" class="form-label">I am a:</label>
-            <select id="loginRole" class="form-input">
-                <option value="student">Student</option>
-                <option value="teacher">Teacher</option>
-                <option value="parent">Parent</option>
-            </select>
-        </div>
-        <div class="form-group">
-            <label for="loginSchool" class="form-label">School</label>
-            <select id="loginSchool" class="form-input"></select>
-        </div>
-        <div class="form-group">
-            <label for="loginGrade" class="form-label">Grade</label>
-            <select id="loginGrade" class="form-input"></select>
-        </div>
+        <!-- Additional fields are presented during sign up -->
         <div id="loginError" class="form-error hidden"></div>
         <button type="submit" class="form-button">Login</button>
         <p class="text-center mt-4">


### PR DESCRIPTION
## Summary
- streamline login form to only ask for username and password
- adjust login logic to read saved profile
- fetch school info lazily to display badge

## Testing
- `npm ci`
- `npm test` *(fails: Missing script)*
- `npx eslint .` *(fails: no config)*
- `npx prettier -c "**/*.{js,html,css}"`
- `npx tsc --noEmit`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_685b9986b2008330a88f1c7db8e163ca