### PR TITLE
Simplify login flow

### DIFF
--- a/docs/chat.js
+++ b/docs/chat.js
@@ -239,9 +239,6 @@ async function generateInitialQuestions(text) {
 
 // Initialize chat with welcome message
 document.addEventListener('DOMContentLoaded', () => {
-    // --- Enable chat input and send button for testing ---
-    if (userInput) userInput.disabled = false;
-    if (sendBtn) sendBtn.disabled = false;
     // Add event listeners only if elements exist
     if (userInput && sendBtn) {
         userInput.addEventListener('keydown', function(e) {
@@ -284,76 +281,27 @@ function setupAuthUI() {
     const loginContainer = document.getElementById('loginContainer');
     const loginError = document.getElementById('loginError');
     const showSignUpBtn = document.getElementById('showSignUpBtn');
-    const signUpModal = document.getElementById('signUpModal');
-    const signUpForm = document.getElementById('signUpForm');
-    const signUpError = document.getElementById('signUpError');
-    const cancelSignUpBtn = document.getElementById('cancelSignUpBtn');
 
-    // --- NEW: Populate school and grade dropdowns, add role selector, mascot update ---
-    const loginRole = document.getElementById('loginRole');
-    const loginSchool = document.getElementById('loginSchool');
-    const loginGrade = document.getElementById('loginGrade');
     let schoolsList = [];
-    // Populate school dropdown
-    function populateSchools() {
-        if (!loginSchool) return;
-        fetch('data/schools.json')
-            .then(res => {
-                if (!res.ok) throw new Error('Schools file not found');
-                return res.json();
-            })
-            .then(schools => {
-                schoolsList = schools;
-                var schoolOptions = '<option value="">Select School</option>';
-                for (var i = 0; i < schools.length; i++) {
-                    schoolOptions += '<option value="' + schools[i].id + '">' + schools[i].name + '</option>';
-                }
-                loginSchool.innerHTML = schoolOptions;
-            })
-            .catch(() => {
-                loginSchool.innerHTML = '<option value="">No schools found</option>';
-            });
-    }
-    // Populate grade dropdown
-    function populateGrades() {
-        if (!loginGrade) return;
-        var gradeOptions = '<option value="">Select Grade</option>';
-        for (var i = 1; i <= 12; i++) {
-            gradeOptions += '<option value="' + i + '">Grade ' + i + '</option>';
+    async function loadSchoolsList() {
+        if (schoolsList.length) return schoolsList;
+        try {
+            const resp = await fetch('data/schools.json');
+            schoolsList = await resp.json();
+        } catch {
+            schoolsList = [];
         }
-        loginGrade.innerHTML = gradeOptions;
+        return schoolsList;
     }
-    // Always populate on DOMContentLoaded
-    if (document.readyState === 'loading') {
-        window.addEventListener('DOMContentLoaded', () => {
-            populateSchools();
-            populateGrades();
-        });
-    } else {
-        populateSchools();
-        populateGrades();
-    }
-    // Mascot update on role change
-    if (loginRole) {
-        loginRole.addEventListener('change', function() {
-            const mascot = document.getElementById('wizardMascot') || document.getElementById('homeworkMascot');
-            if (mascot) {
-                if (loginRole.value === 'teacher') mascot.textContent = '📚🎓';
-                else mascot.textContent = '📚🎒';
-            }
-        });
-    }
+
     // Update login logic to check localStorage
     if (loginForm) {
-        loginForm.addEventListener('submit', function(e) {
+        loginForm.addEventListener('submit', async function(e) {
             e.preventDefault();
             const name = document.getElementById('loginName').value.trim();
             const password = document.getElementById('loginPassword').value;
-            const role = loginRole ? loginRole.value : 'student';
-            const schoolId = loginSchool ? loginSchool.value : '';
-            const grade = loginGrade ? parseInt(loginGrade.value, 10) : null;
-            if (!name || !password || !role || !schoolId || !grade) {
-                loginError.textContent = 'Please fill in all fields (name, password, role, school, grade).';
+            if (!name || !password) {
+                loginError.textContent = 'Please enter your username and password.';
                 loginError.classList.remove('hidden');
                 return;
             }
@@ -373,27 +321,25 @@ function setupAuthUI() {
             currentUser = name;
             currentUserPassword = password;
             loginContainer.style.display = 'none';
+            const chatWrapper = document.getElementById('chatWrapper');
+            if (chatWrapper) chatWrapper.style.display = 'block';
             userInput.disabled = false;
             sendBtn.disabled = false;
             showLogoutButton(true);
-            // Load user profile from users_profiles if available
             let userProfile = null;
             try {
                 const usersProfiles = JSON.parse(localStorage.getItem('users_profiles') || '{}');
                 if (usersProfiles[name]) {
                     userProfile = usersProfiles[name];
-                } else {
-                    // fallback: create minimal profile
-                    const uid = 'uid-' + Math.random().toString(36).slice(2,10);
-                    userProfile = { uid, role, name, schoolId, grade };
                 }
-            } catch {
+            } catch {}
+            if (!userProfile) {
                 const uid = 'uid-' + Math.random().toString(36).slice(2,10);
-                userProfile = { uid, role, name, schoolId, grade };
+                userProfile = { uid, name };
             }
             localStorage.setItem('userProfile', JSON.stringify(userProfile));
-            // Show badge in chat header if available
-            const school = schoolsList.find(s => s.id === schoolId);
+            await loadSchoolsList();
+            const school = schoolsList.find(s => s.id === userProfile.schoolId);
             if (school && school.badgeUrl) {
                 let badge = document.getElementById('schoolBadge');
                 if (!badge) {
@@ -561,8 +507,10 @@ function logoutUser() {
     if (chatContainer) chatContainer.innerHTML = '';
     // Show login, hide chat input
     document.getElementById('loginContainer').style.display = '';
-    document.getElementById('userInput').disabled = true;
-    document.getElementById('sendBtn').disabled = true;
+    const chatWrapper = document.getElementById('chatWrapper');
+    if (chatWrapper) chatWrapper.style.display = 'none';
+    document.getElementById('user-input').disabled = true;
+    document.getElementById('send-button').disabled = true;
     logoutBtn.classList.add('hidden');
     addBotMessage('You have been logged out. Your conversation was saved.');
     // Only clear loginName and loginPassword fields
@@ -1246,6 +1194,8 @@ document.addEventListener('DOMContentLoaded', function setupSignUpWizardWrapper(
             currentUser = userProfile.name;
             currentUserPassword = password;
             document.getElementById('loginContainer').style.display = 'none';
+            const chatWrapper = document.getElementById('chatWrapper');
+            if (chatWrapper) chatWrapper.style.display = 'block';
             userInput.disabled = false;
             sendBtn.disabled = false;
             showLogoutButton(true);

--- a/index.html
+++ b/index.html
@@ -35,22 +35,7 @@
             <label for="loginPassword" class="form-label">Password</label>
             <input type="password" id="loginPassword" class="form-input" required>
         </div>
-        <div class="form-group">
-            <label for="loginRole" class="form-label">I am a:</label>
-            <select id="loginRole" class="form-input">
-                <option value="student">Student</option>
-                <option value="teacher">Teacher</option>
-                <option value="parent">Parent</option>
-            </select>
-        </div>
-        <div class="form-group">
-            <label for="loginSchool" class="form-label">School</label>
-            <select id="loginSchool" class="form-input"></select>
-        </div>
-        <div class="form-group">
-            <label for="loginGrade" class="form-label">Grade</label>
-            <select id="loginGrade" class="form-input"></select>
-        </div>
+        <!-- Additional fields are presented during sign up -->
         <div id="loginError" class="form-error hidden"></div>
         <button type="submit" class="form-button">Login</button>
         <p class="text-center mt-4">
@@ -60,7 +45,7 @@
     </form>
 </div>
 
-<div class="chat-container">
+<div id="chatWrapper" class="chat-container" style="display:none;">
     <main id="chat-area" class="flex-1 overflow-y-auto">
         <!-- Example messages, real messages will be rendered by JS -->
         <div id="chatContainer">
@@ -126,17 +111,23 @@
 <script>
 // Show login container if not logged in
 document.addEventListener('DOMContentLoaded', function() {
+    const loginContainer = document.getElementById('loginContainer');
+    const chatWrapper = document.getElementById('chatWrapper');
     try {
         const userProfile = JSON.parse(localStorage.getItem('userProfile'));
         if (!userProfile || !userProfile.name) {
-            document.getElementById('loginContainer').style.display = 'block';
+            loginContainer.style.display = 'block';
+            chatWrapper.style.display = 'none';
             document.getElementById('user-input').disabled = true;
             document.getElementById('send-button').disabled = true;
         } else {
+            loginContainer.style.display = 'none';
+            chatWrapper.style.display = 'block';
             document.getElementById('logoutBtn').classList.remove('hidden');
         }
     } catch(e) {
-        document.getElementById('loginContainer').style.display = 'block';
+        loginContainer.style.display = 'block';
+        chatWrapper.style.display = 'none';
         document.getElementById('user-input').disabled = true;
         document.getElementById('send-button').disabled = true;
     }


### PR DESCRIPTION
## Summary
- streamline login form to only ask for username and password
- trim unused signup modal variables in login handler

## Testing
- `npm ci`
- `npm test` *(fails: Missing script)*
- `npx eslint .` *(fails: no config)*
- `npx prettier -c "**/*.{js,html,css}"`
- `npx tsc --noEmit`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_685b9986b2008330a88f1c7db8e163ca