### PR TITLE
Sync docs index with root layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,80 +5,151 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bryneven Primary School Helper</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="/styles.css">
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="shortcut icon" href="logo.svg" type="image/svg+xml">
 </head>
 <body>
+<!-- Shared header will be loaded here -->
 <div id="header-container"></div>
 <script>
-    fetch('/header.html')
+  fetch('header.html')
     .then(res => res.text())
     .then(html => {
       document.getElementById('header-container').innerHTML = html;
+    })
+    .catch(() => {
+      document.getElementById('header-container').innerHTML = '<header class="flex flex-col items-center bg-blue-100 rounded-b-xl shadow-md mb-6 px-8 py-6"><h1 class="text-3xl md:text-4xl font-bold text-white bg-blue-600 px-4 py-1 rounded">Bryneven Primary School Helper</h1></header>';
     });
 </script>
-<div class="chat-container">
-    <div class="chat-grid">
-        <div class="chat-main-col">
-            <main id="chat-area" class="chat-messages">
-                <div class="message bot"><p>Hi there! I'm the Bryneven Primary School Helper. Ask me about lessons, homework, or school life!</p></div>
-            </main>
+
+<!-- Login Container -->
+<div id="loginContainer" class="auth-container mb-4" style="display: none;">
+    <h2 class="text-2xl font-bold mb-4 text-center">Welcome Back!</h2>
+    <form id="loginForm" class="space-y-4">
+        <div class="form-group">
+            <label for="loginName" class="form-label">Username</label>
+            <input type="text" id="loginName" class="form-input" required>
         </div>
+        <div class="form-group">
+            <label for="loginPassword" class="form-label">Password</label>
+            <input type="password" id="loginPassword" class="form-input" required>
+        </div>
+        <!-- Additional fields are presented during sign up -->
+        <div id="loginError" class="form-error hidden"></div>
+        <button type="submit" class="form-button">Login</button>
+        <p class="text-center mt-4">
+            <span class="text-sm">Don't have an account?</span>
+            <a href="signup.html" id="showSignUpBtn" class="text-blue-500 hover:underline ml-1">Sign Up</a>
+        </p>
+    </form>
+</div>
 
-        <aside class="chat-sidebar">
-            <div class="sidebar-section">
-                <label class="sidebar-label" for="suggestion-select">Quick topics</label>
-                <select id="suggestion-select" class="sidebar-select">
-                    <option value="">Choose a topic…</option>
-                    <option>About our school</option>
-                    <option>Purple Mash help</option>
-                    <option>School hours</option>
-                    <option>Math tutoring</option>
-                    <option>Homework tips</option>
-                    <option>Explain fractions</option>
-                    <option>Reading practice</option>
-                    <option>Science project ideas</option>
-                </select>
-            </div>
-
-            <div class="sidebar-tip" id="contextTip">
-                <div class="tip-text">Tip: Highlight a word in my reply, then right-click (or long-press) to Describe, Define, Explain, or get an Example.</div>
-                <div class="tip-actions">
-                    <button id="dismissTip" class="tip-dismiss">Got it</button>
-                    <label class="tip-toggle"><input type="checkbox" id="showTipToggle" checked> Show tip next time</label>
+<div id="chatWrapper" class="chat-container" style="display:none;">
+    <main id="chat-area" class="flex-1 overflow-y-auto">
+        <!-- Example messages, real messages will be rendered by JS -->
+        <div id="chatContainer"></div>
+    </main>
+    
+    <!-- Sign-up Wizard Modal -->
+    <div id="signUpWizardModal" class="fixed inset-0 bg-black bg-opacity-50 hidden flex items-center justify-center z-50">
+        <div class="bg-white p-6 rounded-lg shadow-xl w-11/12 max-w-md relative">
+            <button id="closeWizardBtn" class="absolute top-2 right-2 text-gray-500 hover:text-gray-700">&times;</button>
+            <div class="mb-4 flex justify-center">
+                <div id="wizardStepIndicator" class="flex space-x-2">
+                    <div class="w-3 h-3 rounded-full bg-blue-400"></div>
+                    <div class="w-3 h-3 rounded-full bg-gray-300"></div>
+                    <div class="w-3 h-3 rounded-full bg-gray-300"></div>
+                    <div class="w-3 h-3 rounded-full bg-gray-300"></div>
                 </div>
             </div>
-
-            <div class="sidebar-section">
-                <label class="sidebar-label" for="temperatureSlider">Temperature <span id="temperatureValue">0.7</span></label>
-                <input id="temperatureSlider" type="range" min="0" max="1" step="0.1" value="0.7">
+            <div id="wizardError" class="hidden text-red-500 text-sm mb-4 text-center"></div>
+            <div id="wizardStepContent" class="mb-4">
+                <!-- Content will be filled by JavaScript -->
             </div>
-            <div class="sidebar-section">
-                <label class="sidebar-label" for="maxTokensSlider">Max words <span id="maxTokensValue">400</span></label>
-                <input id="maxTokensSlider" type="range" min="150" max="700" step="50" value="400">
-            </div>
-        </aside>
+        </div>
+        <canvas id="confettiCanvas" class="absolute top-0 left-0 w-full h-full pointer-events-none hidden"></canvas>
     </div>
 
+    <div class="suggestions-area">
+        <p class="suggestions-title">Try asking about:</p>
+        <div class="suggestion-buttons">
+            <button class="suggestion-btn">About our school</button>
+            <button class="suggestion-btn">Purple Mash help</button>
+            <button class="suggestion-btn">School hours</button>
+            <button class="suggestion-btn">Math tutoring</button>
+        </div>
+    </div>
+    
     <div class="input-area">
-        <textarea id="user-input" placeholder="Type your question here..." rows="2"></textarea>
-        <button id="send-button"><i class="fas fa-paper-plane"></i></button>
+        <textarea id="user-input" placeholder="Type your question here..." rows="1" style="min-height:2.5rem;max-height:8rem;resize:vertical;width:100%;padding:0.5rem;font-size:1rem;"></textarea>
+        <button id="send-button" style="height:2.5rem;width:2.5rem;"><i class="fas fa-paper-plane"></i></button>
     </div>
-
+    <div id="ai-warning" style="display:none;color:#f44336;text-align:center;margin-top:0.5rem;font-size:0.95rem;padding:0.5rem;background-color:#fff3f3;border:1px solid #ffdddd;border-radius:8px;margin:0.5rem 1rem;">
+        AI backend is not available. The chatbot will run in limited mode.
+    </div>
+    
     <footer>
-        Powered by DeepSeek via OpenRouter | (c) 2025 Bryneven Primary School
+        <div class="flex justify-between items-center w-full">
+            <span>Powered by AI | © 2023-2025 Bryneven Primary School</span>
+            <div>
+                <a id="showSignUpBtn2" href="signup.html" class="text-blue-500 hover:underline">Sign Up</a>
+                <button id="logoutBtn" class="text-red-500 hover:underline hidden ml-4">Logout</button>
+            </div>
+        </div>
     </footer>
 </div>
 
+<!-- Add confetti script for signup success animation -->
+<script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+
+<script src="data.js" type="module"></script>
+<script src="chat.js" type="module"></script>
+
 <script>
-  document.addEventListener('DOMContentLoaded', function() {
-    var input = document.getElementById('user-input');
-    if(input) input.focus();
-  });
+// Show login container if not logged in
+document.addEventListener('DOMContentLoaded', function() {
+    const loginContainer = document.getElementById('loginContainer');
+    const chatWrapper = document.getElementById('chatWrapper');
+    try {
+        const userProfile = JSON.parse(localStorage.getItem('userProfile'));
+        if (!userProfile || !userProfile.name) {
+            loginContainer.style.display = 'block';
+            chatWrapper.style.display = 'none';
+            document.getElementById('user-input').disabled = true;
+            document.getElementById('send-button').disabled = true;
+        } else {
+            loginContainer.style.display = 'none';
+            chatWrapper.style.display = 'block';
+            document.getElementById('logoutBtn').classList.remove('hidden');
+        }
+    } catch(e) {
+        loginContainer.style.display = 'block';
+        chatWrapper.style.display = 'none';
+        document.getElementById('user-input').disabled = true;
+        document.getElementById('send-button').disabled = true;
+    }
+    
+
+    
+    // Close button for wizard
+    document.getElementById('closeWizardBtn').addEventListener('click', function() {
+        document.getElementById('signUpWizardModal').classList.add('hidden');
+    });
+    
+    // Warn if backend is unreachable
+    fetch('https://bryneven-chatbot-api.vercel.app/api/chat', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({prompt: 'test'})
+    })
+    .then(r => {
+        if(!r.ok) document.getElementById('ai-warning').style.display = 'block';
+    })
+    .catch(() => {
+        document.getElementById('ai-warning').style.display = 'block';
+    });
+});
 </script>
-<script>window.CHATBOT_API_BASE = window.CHATBOT_API_BASE || '';</script>
-<script type="module" src="/data.js"></script>
-<script type="module" src="/chat.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- copy the latest root `index.html` layout into `docs/index.html` so GitHub Pages shows the working chatbot experience
- adjust asset paths to use doc-local references for the shared header, favicon, signup link, and module scripts so everything loads when served from `/docs`

## Suggestions
→ (optional) Automate copying the root site into `docs/` via an npm script so GitHub Pages stays in sync without manual edits.
  Learner Note: An npm script is a custom command defined in `package.json` that runs with `npm run`. [Docs](https://docs.npmjs.com/cli/v10/using-npm/scripts)
→ (optional) Add deployment checks that fail if the root and `docs/` chat UIs diverge to catch drift early.
  Learner Note: A deployment check is an automated test that ensures code is ready before publishing. [Docs](https://docs.github.com/en/actions/deployment/about-deployments)


------
https://chatgpt.com/codex/tasks/task_e_68d297feef4c8330816a5196f02caef6